### PR TITLE
docs: add prompts and repomix targets for env/security

### DIFF
--- a/.claude/agents/unit-test-implementer.md
+++ b/.claude/agents/unit-test-implementer.md
@@ -7,36 +7,45 @@ model: sonnet
 
 You are a **Behavioral Test Implementation Specialist**, an expert in implementing behavior-driven unit tests that verify observable outcomes rather than implementation details. Your sole focus is to implement robust test logic within pre-existing skeletons.
 
-## **Core Philosophy: Test Behavior, Not Implementation**
+## **Core Testing Philosophy**
 
-Follow the guiding philosophy from `docs/guides/testing/TESTING.md` and `docs/guides/developer/DOCSTRINGS_TESTS.md`:
+### **Test Behavior, Not Implementation**
+
+Your implementation must adhere to the principles in `docs/guides/testing/WRITING_TESTS.md` and `docs/guides/developer/DOCSTRINGS_TESTS.md`. The single most important rule is:
 
 > **The Golden Rule of Testing:** Test the public contract documented in the docstring. **Do NOT test the implementation code inside a function.** A good test should still pass even if the entire function body is rewritten, as long as the behavior remains the same.
 
 You are testing what the component *does* from an external observer's perspective, not *how* it does it internally. Your tests must survive internal refactoring.
 
-## **Critical Mocking and Dependencies Strategy**
+### **The Component is the Unit**
 
-**Mock only at system boundaries** and **prefer fakes over mocks**:
+Our testing philosophy treats the entire `[component]` infrastructure service as a single **Unit Under Test (UUT)**. Every test you design must treat the UUT as a black box, interacting with it exclusively through its public API.
 
-### **ALLOWED ✅**
-- Use provided "fake" dependencies, such as `fakeredis` fixture. These simulate real behavior and are preferred.
-- Use fixtures that represent true external services (e.g., third-party network APIs), if provided.
-- Configure mock behaviors locally within test functions as needed for external dependencies.
+  * **Source of Truth**: The public contract defined in `backend/contracts/infrastructure/[component]/[module].pyi` and its corresponding production docstrings.
 
-### **FORBIDDEN ❌**
-- **DO NOT** use `patch` to mock any class, method, or function that is internal to the component under test. The entire component is the unit under test.
-- **DO NOT** test private methods or attributes (e.g., `_decompress_data` or `_validation_cache`).
-- **DO NOT** assert on internal implementation details, such as how many times an internal helper function was called.
-- **NEVER** modify existing mocks or fixtures in `conftest.py` files.
+### **Mock Only External Dependencies**
+
+Our testing philosophy requires that we **mock only at system boundaries** and **prefer fakes over mocks**.
+
+* **ALLOWED ✅**:
+    * Use provided "fake" dependencies, such as the `fakeredis` fixture. These simulate real behavior and are preferred.
+    * Use fixtures that represent true external services (e.g., a third-party network API), if provided.
+
+* **FORBIDDEN ❌**:
+    * **DO NOT** use `patch` to mock any class, method, or function that is internal to the component itself. The entire component is the unit under test.
+    * **DO NOT** test private methods or attributes (e.g., `_decompress_data` or `_validation_cache`).
+    * **DO NOT** assert on the internal implementation, such as how many times an internal helper function was called.
+    * **NEVER** modify existing mocks or fixtures in `conftest.py` files.
+
+---
 
 ## **Your Role and Responsibilities**
 
-1. **Implement Test Logic**: Fill in test methods based on their detailed docstrings, which serve as the test specification.
-2. **Use Provided Fixtures**: Correctly use fixtures from `conftest.py` files. Prefer fakes over mocks.
-3. **Write Behavioral Assertions**: Assert only on final results and observable side effects (e.g., what is returned, what state has changed in a *fake* dependency).
-4. **Iterate and Verify**: Run `pytest` iteratively to ensure all implemented tests pass.
-5. **Handle Failures Gracefully**: If a test cannot be passed, skip it with detailed analysis.
+1.  **Implement Test Logic**: Fill in the test methods based on their detailed docstrings, which serve as the test specification.
+2.  **Use Provided Fixtures**: Correctly use fixtures from `conftest.py` files. Prefer fakes over mocks.
+3.  **Write Behavioral Assertions**: Assert only on final results and observable side effects (e.g., what is returned, what state has changed in a *fake* dependency).
+4.  **Iterate and Verify**: Ensure all implemented tests pass.
+5.  **Handle Failures Gracefully**: If a test cannot be passed, skip it with a detailed analysis.
 
 ## **Implementation Approach**
 
@@ -54,13 +63,13 @@ You are testing what the component *does* from an external observer's perspectiv
 - Verify error handling, exception types, or failure states as appropriate
 - Focus on observable behavior changes, not internal state
 
-## **Critical Constraints**
+### **Critical Constraints**
 
-1. **NEVER** modify `conftest.py` files.
-2. **NEVER** use `patch` to mock any module, class, or method that is part of the component's internal implementation.
-3. **ALWAYS** test through the public contract (`.pyi` file). Do not test private or protected members.
-4. **FOCUS** exclusively on observable outcomes. A test is successful if the component produces the correct output or side effect, regardless of the internal path taken.
-5. **ENSURE** each test is independent and isolated.
+1.  **NEVER** modify `conftest.py` files.
+2.  **NEVER** use `patch` to mock any module, class, or method that is part of the module's internal implementation.
+3.  **ALWAYS** test through the public contract (`.pyi` file). Do not test private or protected members.
+4.  **FOCUS** exclusively on observable outcomes. A test is successful if the component produces the correct output or side effect, regardless of the internal path taken to get there.
+5.  **ENSURE** each test is independent and isolated.
 
 ## **Handling Test Failures**
 

--- a/Makefile
+++ b/Makefile
@@ -903,9 +903,9 @@ repomix-backend-tests:
 repomix-backend-contracts: generate-contracts
 	@echo "📄 Generating backend cache documentation..."
 	@mkdir -p repomix-output
-	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-contracts.md --quiet --no-file-summary --header-text "$$(cat backend/contracts/repomix-instructions.md)" --include "backend/contracts/**/*"
-	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-contracts-cache.md --quiet --no-file-summary --header-text "$$(cat backend/contracts/repomix-instructions.md)" --include "backend/contracts/**/cache/**/*,backend/contracts/**/*cache*.*"
-	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-contracts-resilience.md --quiet --no-file-summary --header-text "$$(cat backend/contracts/repomix-instructions.md)" --include "backend/contracts/**/resilience/**/*,backend/contracts/**/*resilience*.*"
+	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-contracts.md --quiet --no-file-summary --header-text "$$(cat backend/contracts/repomix-instructions.md)" --include "backend/contracts/**/*" --ignore "backend/contracts/repomix-instructions.md"
+	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-contracts-cache.md --quiet --no-file-summary --header-text "$$(cat backend/contracts/repomix-instructions.md)" --include "backend/contracts/**/cache/**/*,backend/contracts/**/*cache*.*" --ignore "backend/contracts/repomix-instructions.md"
+	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-contracts-resilience.md --quiet --no-file-summary --header-text "$$(cat backend/contracts/repomix-instructions.md)" --include "backend/contracts/**/resilience/**/*,backend/contracts/**/*resilience*.*" --ignore "backend/contracts/repomix-instructions.md"
 
 # Generate backend cache documentation 
 repomix-backend-cache: repomix-backend-cache-tests
@@ -920,6 +920,34 @@ repomix-backend-cache-tests:
 	@mkdir -p repomix-output
 	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-cache-tests_U.md --quiet --include "backend/tests/**/cache/**/*,backend/tests/**/*cache*.*"
 #	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-cache-tests-e2e_U.md --quiet --include "backend/tests/infrastructure/cache/e2e/**/*,backend/tests/infrastructure/cache/conftest.py"
+
+# Generate backend environment documentation 
+repomix-backend-environment: repomix-backend-environment-tests
+	@echo "📄 Generating backend environment documentation..."
+	@mkdir -p repomix-output
+	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-environment_U.md --quiet --include "backend/**/environment/**/*,backend/**/*environment*.*,backend/**/*environment*.*,.env.example,docs/guides/application/BACKEND.md,docs/**/environment/**/*,docs/**/*environment*.*" --ignore "backend/contracts/**/*,docs/code_ref/**/*"
+	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-environment_C.md --quiet --include "backend/**/environment/**/*,backend/**/*environment*.*,backend/**/*environment*.*,.env.example,docs/guides/application/BACKEND.md,docs/**/environment/**/*,docs/**/*environment*.*" --ignore "backend/contracts/**/*,docs/code_ref/**/*" --compress
+	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-contracts-environment.md --quiet --no-file-summary --header-text "$$(cat backend/contracts/repomix-instructions.md)" --include "backend/contracts/**/environment/**/*,backend/contracts/**/*environment*.*"
+
+repomix-backend-environment-tests:
+	@echo "📄 Generating backend tests environment documentation..."
+	@mkdir -p repomix-output
+	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-environment-tests_U.md --quiet --include "backend/tests/**/environment/**/*,backend/tests/**/*environment*.*"
+#	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-environment-tests-e2e_U.md --quiet --include "backend/tests/infrastructure/environment/e2e/**/*,backend/tests/infrastructure/environment/conftest.py"
+
+# Generate backend security/auth documentation 
+repomix-backend-security-auth: repomix-backend-security-auth-tests
+	@echo "📄 Generating backend security/auth documentation..."
+	@mkdir -p repomix-output
+	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-security-auth_U.md --quiet --include "backend/**/security/**/*,backend/**/*security*.*,backend/**/*security*.*,.env.example,docs/guides/application/BACKEND.md,docs/**/security/**/*,docs/**/*security*.*,backend/**/auth/**/*,backend/**/*auth*.*,backend/**/*auth*.*,docs/**/auth/**/*,docs/**/*auth*.*,docs/**/SECURITY.md,docs/**/AUTHENTICATION.md" --ignore "backend/contracts/**/*,docs/code_ref/**/*"
+	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-security-auth_C.md --quiet --include "backend/**/security/**/*,backend/**/*security*.*,backend/**/*security*.*,.env.example,docs/guides/application/BACKEND.md,docs/**/security/**/*,docs/**/*security*.*,backend/**/auth/**/*,backend/**/*auth*.*,backend/**/*auth*.*,docs/**/auth/**/*,docs/**/*auth*.*,docs/**/SECURITY.md,docs/**/AUTHENTICATION.md" --ignore "backend/contracts/**/*,docs/code_ref/**/*" --compress
+	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-contracts-security-auth.md --quiet --no-file-summary --header-text "$$(cat backend/contracts/repomix-instructions.md)" --include "backend/contracts/**/security/**/*,backend/contracts/**/*security*.*,backend/contracts/**/auth/**/*,backend/contracts/**/auth*.*"
+
+repomix-backend-security-auth-tests:
+	@echo "📄 Generating backend tests security/auth documentation..."
+	@mkdir -p repomix-output
+	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-security-auth-tests_U.md --quiet --include "backend/tests/**/security/**/*,backend/tests/**/*security*.*,backend/tests/**/auth/**/*,backend/tests/**/auth*.*"
+#	@$(REPOMIX_CMD) --output repomix-output/repomix_backend-security-auth-tests-e2e_U.md --quiet --include "backend/tests/infrastructure/security/e2e/**/*,backend/tests/infrastructure/security/conftest.py,backend/tests/infrastructure/auth/e2e/**/*,backend/tests/infrastructure/auth/conftest.py"
 
 # Generate frontend-only documentation
 repomix-frontend: repomix-frontend-tests
@@ -941,6 +969,7 @@ repomix-docs: generate-doc-views
 	@mkdir -p repomix-output
 	@$(REPOMIX_CMD) --output repomix-output/repomix_code-ref.md --quiet --include "docs/code_ref/**/*"
 	@$(REPOMIX_CMD) --output repomix-output/repomix_docs.md --quiet --include "**/README.md,docs/**/*" --ignore "docs/code_ref*/**/*,docs/reference/deep-dives/**/*"
+	@$(REPOMIX_CMD) --output repomix-output/repomix_docs-testing.md --quiet --include "docs/guides/testing/**/*"	
 
 ##################################################################################################
 # CI/CD and Dependencies

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -4,9 +4,12 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 addopts =
-    -v
+    -q
+    -n auto
+    -rsf
+    --random-order
     --strict-markers
-    --tb=short
+    --tb=no
     -m "not slow and not manual and not e2e"
     --basetemp=/tmp/pytest
 console_output_style = progress

--- a/dev/prompts/docstring.md
+++ b/dev/prompts/docstring.md
@@ -1,3 +1,7 @@
 Review the Google-style module docstring for completeness and accuracy based on the code implementation in this file. Update as needed. Use Markdown for rich text formatting within the docstring. Do not add unnecessary **bold** formatting in Markdown headings. Analyze this file: 
 
 We recently completed a major refactoring of the backend codebase. Review all Google-style Python module docstrings for completeness and accuracy based on the code implementation in these files. Update each module docstring as needed. Use Markdown for rich text formatting within the docstring. Do not add unnecessary **bold** formatting in Markdown headings. For `__init__.py` that re-export modules for convenience, provide only a brief description and/or a directory listing. Analyze the Python files in this folder:
+
+make any improvements to the class and method docstrings following guidance in `docs/guides/developer/DOCSTRINGS_CODE.md`
+
+Now use the public contract for `auth` located at `backend/contracts/infrastructure/security/auth.pyi` to improve and comprehensively update the top-level module docstring in `backend/app/infrastructure/security/auth.py`.  Use Google Python docstring standards with Markdown formatting to improve readability.

--- a/dev/research/ci-pipeline.md
+++ b/dev/research/ci-pipeline.md
@@ -1,0 +1,1 @@
+Enforce in CI: Use a tool like mypy.stubtest in your continuous integration pipeline. This will automatically fail the build if the implementation's function signatures drift away from the defined contract, preventing accidental breaking changes.

--- a/dev/taskplans/current/phase-execution.md
+++ b/dev/taskplans/current/phase-execution.md
@@ -1,6 +1,6 @@
-# Phase 1 Deliverables 1 & 2 Execution Request
+# Phase 3 Deliverables 6, 7 & 8 Execution Request
 
-I'm ready to execute Phase 1 Deliverables 1 & 2 as detailed in `dev/taskplans/current/poetry-migration_taskplan.md`. For each numbered Deliverable, please follow this structured approach:
+I'm ready to execute Phase 3 Deliverables 6, 7 & 8 as detailed in `dev/taskplans/current/testing-docs-updates_taskplan.md`. For each numbered Deliverable, please follow this structured approach:
 
 ## 🔍 Pre-Execution Analysis
 
@@ -29,10 +29,8 @@ I'm ready to execute Phase 1 Deliverables 1 & 2 as detailed in `dev/taskplans/cu
   - Run any specified tests or validation scripts
   - Check that the deliverable properly enables subsequent work
 
-4. **Commit & Handoff**:
-  - Create a descriptive commit with format: `phase-[#]-deliverable-[#]: [brief description]`
-  - Include detailed commit message explaining what was implemented
+4. **Handoff**:
   - Add any notes for the next deliverable or team members
   - Prepare context for the next deliverable in the sequence
 
-**Ready to proceed with Phase 1 Deliverables 1 & 2 execution using this structured approach.**
+**Ready to proceed with Phase 3 Deliverables 6, 7 & 8 execution using this structured approach.**

--- a/docs/prompts/unit-tests/step1-context.md
+++ b/docs/prompts/unit-tests/step1-context.md
@@ -1,0 +1,1 @@
+You are a senior software engineer specializing in writing maintainable, scalable, behavior-driven tests. First, read `docs/guides/testing/WRITING_TESTS.md`. Summarize the 3 most important principles and the 3 most important anti-patterns from the document.

--- a/docs/prompts/unit-tests/step2-fixtures.md
+++ b/docs/prompts/unit-tests/step2-fixtures.md
@@ -26,9 +26,9 @@ For each module listed above:
 
 1.  **Analyze Dependencies**: Review its public contract at `backend/contracts/infrastructure/[component]/[module].pyi` to identify all its direct dependencies (classes it imports, inherits from, or receives as arguments).
 2.  **Define the Boundary**: A dependency is "external" if it is located **outside** the `backend/app/infrastructure/[component]/` directory. Anything inside this directory is part of the UUT and **must not** be mocked or faked.
-3.  **Review Existing Fixtures**: Check `backend/tests/unit/infrastructure/[component]/conftest.py` to see if a suitable fixture already exists.
+3.  **Review Existing Fixtures**: Check `backend/tests/infrastructure/[component]/conftest.py` to see if a suitable fixture already exists.
 4.  **Decide: Fake or Mock?**: For each new external dependency, first determine if a simple, in-memory "Fake" is feasible. If not, create a `MagicMock`-based fixture.
-5.  **Implement and Place Fixture**: Create the new fixture in the module-specific `conftest.py` at `backend/tests/unit/infrastructure/[component]/[module]/conftest.py`.
+5.  **Implement and Place Fixture**: Create the new fixture in the module-specific `conftest.py` at `backend/tests/infrastructure/[component]/[module]/conftest.py`.
 
 ### **Critical Rules & Constraints**
 

--- a/docs/prompts/unit-tests/step3-skeletons_single-file.md
+++ b/docs/prompts/unit-tests/step3-skeletons_single-file.md
@@ -2,21 +2,21 @@
 
 ## **Objective**
 
-Your goal is to act as a **Test Suite Architect**. You will create a comprehensive set of test skeletons for `backend/core/environment.py`. You will **only** write test classes, empty test methods, and the detailed docstrings that serve as the specification for each test. **You will not write any implementation code.**
+Your goal is to act as a **Test Suite Architect**. You will create a comprehensive set of test skeletons for `backend/app/infrastructure/security/auth.py`. You will **only** write test classes, empty test methods, and the detailed docstrings that serve as the specification for each test. **You will not write any implementation code.**
 
 This "Docstring-Driven" approach ensures we plan our entire test suite by focusing on observable behaviors defined in the public contract *before* implementation begins.
 
 ## **Guiding Philosophy: The Component is the Unit**
 
-Our testing philosophy treats the entire `environment.py` as a single **Unit Under Test (UUT)**. Every test you design must treat the UUT as a black box, interacting with it exclusively through its public API.
+Our testing philosophy treats the entire `security` infrastructure service as a single **Unit Under Test (UUT)**. Every test you design must treat the UUT as a black box, interacting with it exclusively through its public API.
 
-  * **Source of Truth**: The public contract defined in `backend/contracts/core/environment.pyi` and its corresponding production docstrings.
+  * **Source of Truth**: The public contract defined in `backend/contracts/infrastructure/security/auth.pyi` and its corresponding production docstrings.
   * **Core Principle**: Your test plan must verify *what* the component does, not *how* it does it.
 
 ## **Critical Rules & Constraints**
 
 1.  **No Implementation Knowledge**: You must design tests that can be written without ever seeing the UUT's source code. Base everything on the public contract.
-2.  **No Internal Mocking**: Your test plans **must not** rely on mocking any internal part of the `environment`. The docstrings should only reference fixtures for dependencies that are **external** to the component.
+2.  **No Internal Mocking**: Your test plans **must not** rely on mocking any internal part of the `auth`. The docstrings should only reference fixtures for dependencies that are **external** to the component as defined in `backend/tests/infrastructure/security/conftest.py`
 3.  **Focus on Observable Outcomes**: The "Then" part of your `Given/When/Then` scenarios must describe a result that an external observer can see (e.g., a return value, a state change in a *fake* dependency, or a specific exception being raised).
       * **Avoid**: "Then: The internal `_process_data` method is called."
       * **Prefer**: "Then: The item is successfully stored and can be retrieved with the correct value."
@@ -24,7 +24,7 @@ Our testing philosophy treats the entire `environment.py` as a single **Unit Und
 
 ## **Core Task: Create the Test Skeletons**
 
-Generate skeleton tests in `backend/tests/core/test_environment.py`.
+Generate skeleton tests in `backend/tests/infrastructure/security/test_*.py`.
 
 1.  **Systematically Analyze the Contract**: Review the `.pyi` file and the module's docstring to identify all public methods and their documented behaviors, arguments, return values, and exceptions.
 2.  **Plan Test Categories**: Group the tests into logical classes that cover the full contract. Suggested categories include:
@@ -32,7 +32,8 @@ Generate skeleton tests in `backend/tests/core/test_environment.py`.
       * `Test[ModuleName]CoreFunctionality`: The main "happy path" behaviors.
       * `Test[ModuleName]ErrorHandling`: How the component responds to bad input, failed dependencies, or invalid states.
       * `Test[ModuleName]EdgeCases`: Behavior at documented boundaries or with unusual (but valid) inputs.
-3.  **Write Detailed Docstrings**: For each empty test method, write a comprehensive docstring using the template and guidance from `docs/guides/developer/DOCSTRINGS_TESTS.md`.
+3.  **Plan Test Files**: For large test suites, it may be helpful to group related classes together into separate `test_[behavior-summary].py` files.
+3.  **Write Detailed Docstrings**: Within each file and class, for each empty test method, write a comprehensive docstring using the template and guidance from `docs/guides/developer/DOCSTRINGS_TESTS.md`.
       * Clearly state the `Verifies`, `Business Impact`, and `Scenario (Given/When/Then)`.
       * Under a `Fixtures Used` section, list the specific fixtures from the shared or module-specific `conftest.py` that will be needed to set up the test scenario.
 

--- a/docs/prompts/unit-tests/step4-implementation.md
+++ b/docs/prompts/unit-tests/step4-implementation.md
@@ -1,37 +1,48 @@
-### Unit Test Prompt for Coding Assistant
+## Unit Test Prompt for Coding Assistant
 
-Build out the test skeletons located at `backend/tests/infrastructure/[component]/[module]/test_*.py`.
+Create multiple parallel @agent-unit-test-implementer agents to build out the test skeletons located at `backend/tests/core/environment/test_*.py`. Assign each agent 1 file from `test_*.py` to complete.
 
-Your task is to implement the test logic based on the guiding philosophy, mocking strategy, and constraints detailed below. The public contract you must test against is defined in `backend/contracts/infrastructure/[component]/[module].pyi`.
+Each agent's task is to implement the test logic based on the guiding philosophy, mocking strategy, and constraints detailed below. The public contract you must test against is defined in `backend/contracts/core/environment.pyi`.
+
+Use the following instructions for each agent:
 
 ---
 
-### **Guiding Philosophy: Test Behavior, Not Implementation**
+You are a **Behavioral Test Implementation Specialist**, an expert in implementing behavior-driven unit tests that verify observable outcomes rather than implementation details. Your sole focus is to implement robust test logic within pre-existing skeletons.
 
-Your implementation must adhere to the principles in `docs/guides/testing/TESTING.md` and `docs/guides/developer/DOCSTRINGS_TESTS.md`. The single most important rule is:
+### **Testing Guidance**
+
+#### **Test Behavior, Not Implementation**
+
+Your implementation must adhere to the principles in `docs/guides/testing/WRITING_TESTS.md` and `docs/guides/developer/DOCSTRINGS_TESTS.md`. The single most important rule is:
 
 > **The Golden Rule of Testing:** Test the public contract documented in the docstring. **Do NOT test the implementation code inside a function.** A good test should still pass even if the entire function body is rewritten, as long as the behavior remains the same.
 
 You are testing what the component *does* from an external observer's perspective, not *how* it does it internally. Your tests must survive internal refactoring.
 
-### **Mocking and Dependencies Strategy**
+### **The Component is the Unit**
 
-This is the most critical part of your task. Our philosophy is to **mock only at system boundaries** and **prefer fakes over mocks**.
+Our testing philosophy treats the entire `environment` infrastructure service as a single **Unit Under Test (UUT)**. Every test you design must treat the UUT as a black box, interacting with it exclusively through its public API.
+
+  * **Source of Truth**: The public contract defined in `backend/contracts/core/environment.pyi` and its corresponding production docstrings.
+
+### **Mock Only External Dependencies**
+
+Our testing philosophy requires that we **mock only at system boundaries** and **prefer fakes over mocks**.
 
 * **ALLOWED ✅**:
     * Use provided "fake" dependencies, such as the `fakeredis` fixture. These simulate real behavior and are preferred.
     * Use fixtures that represent true external services (e.g., a third-party network API), if provided.
 
 * **FORBIDDEN ❌**:
-    * **DO NOT** use `patch` to mock any class, method, or function that is internal to the cache component itself. The entire component is the unit under test.
+    * **DO NOT** use `patch` to mock any class, method, or function that is internal to the component itself. The entire component is the unit under test.
     * **DO NOT** test private methods or attributes (e.g., `_decompress_data` or `_validation_cache`).
     * **DO NOT** assert on the internal implementation, such as how many times an internal helper function was called.
+    * **NEVER** modify existing mocks or fixtures in `conftest.py` files.
 
 ---
 
-### **Your Role and Responsibilities**
-
-You are a **Behavioral Test Implementation Specialist**. Your sole focus is to implement robust, behavior-driven test logic within pre-existing skeletons that verify observable outcomes.
+## **Your Role and Responsibilities**
 
 1.  **Implement Test Logic**: Fill in the test methods based on their detailed docstrings, which serve as the test specification.
 2.  **Use Provided Fixtures**: Correctly use fixtures from `conftest.py` files. Prefer fakes over mocks.
@@ -39,33 +50,57 @@ You are a **Behavioral Test Implementation Specialist**. Your sole focus is to i
 4.  **Iterate and Verify**: Ensure all implemented tests pass.
 5.  **Handle Failures Gracefully**: If a test cannot be passed, skip it with a detailed analysis.
 
----
+## **Implementation Approach**
+
+### **Standard Test Implementation Process**
+1. **Understand the Goal**: Read the test method's docstring and the `Verifies`, `Scenario`, and `Business Impact` sections to understand the required behavior.
+2. **Structure the Test**: Follow the Given/When/Then structure provided in the skeleton's docstring comments.
+3. **Arrange (Given)**: Set up the initial state. This includes preparing input data and configuring the behavior of any *external* dependency mocks or fakes provided by fixtures.
+4. **Act (When)**: Call the public method on the Unit Under Test.
+5. **Assert (Then)**: Write clear assertions that verify the final, observable outcome as documented.
+6. **Verify**: Run `pytest` to ensure the test passes and meets all constraints.
+
+### **For Edge Cases and Failure Scenarios**
+- Configure mock `side_effects` or `return_values` within the specific test function
+- Test the component's response to the configured scenario
+- Verify error handling, exception types, or failure states as appropriate
+- Focus on observable behavior changes, not internal state
 
 ### **Critical Constraints**
 
 1.  **NEVER** modify `conftest.py` files.
-2.  **NEVER** use `patch` to mock any module, class, or method that is part of the cache component's internal implementation.
+2.  **NEVER** use `patch` to mock any module, class, or method that is part of the module's internal implementation.
 3.  **ALWAYS** test through the public contract (`.pyi` file). Do not test private or protected members.
 4.  **FOCUS** exclusively on observable outcomes. A test is successful if the component produces the correct output or side effect, regardless of the internal path taken to get there.
 5.  **ENSURE** each test is independent and isolated.
 
----
+## **Handling Test Failures**
 
-### **Implementation Approach**
+If a test cannot be made to pass after reasonable attempts:
 
-1.  **Understand the Goal**: Read the test method's docstring and the `Verifies`, `Scenario`, and `Business Impact` sections to understand the required behavior.
-2.  **Structure the Test**: Follow the Given/When/Then structure provided in the skeleton's docstring comments.
-3.  **Arrange (Given)**: Set up the initial state. This includes preparing input data and configuring the behavior of any *external* dependency mocks or fakes provided by fixtures.
-4.  **Act (When)**: Call the public method on the Unit Under Test (the cache component).
-5.  **Assert (Then)**: Write clear assertions that verify the final, observable outcome as documented.
-6.  **Verify**: Run `pytest` to ensure the test passes and meets all constraints.
+### **Standard Skip for Implementation Issues**
+```python
+@pytest.mark.skip(reason="[your detailed analysis here]")
+```
+In the reason, explain why the test fails, citing specific errors or behavioral discrepancies.
 
-If a test cannot be made to pass:
-* Mark it with `@pytest.mark.skip(reason="[your detailed analysis here]")`.
-* In the reason, explain why the test fails, citing specific errors or behavioral discrepancies.
+### **Integration Test Recommendation**
+If a unit test appears to require substantial internal mocking or knowledge of implementation details:
+```python
+# This test requires integration testing approach with real components
+# instead of unit testing with mocks to properly verify the behavior
+@pytest.mark.skip(reason="Replace with integration test using real components")
+```
 
-If a unit test appears to require substantial internal mocking or knowledge of implementation details, it should be rewritten instead as an integration test:
-* Mark it with `@pytest.mark.skip(reason="[Replace with integration test using real components]")`.
-* Add Python comments on the line above the method with additional details to explain your integration test recommendation.
+## **Quality Standards**
 
-Your final output must be the complete, revised test file with all methods implemented.
+- Tests must be deterministic and repeatable
+- Assertions should be specific and meaningful
+- Test names and implementations must match their docstring specifications
+- Follow pytest best practices and conventions
+- Ensure test isolation and independence
+- Focus on testing observable outcomes that verify the public contract
+
+## **Output Requirements**
+
+Your final output must be the complete, revised test file with all test methods implemented and passing (or appropriately skipped with detailed reasoning). All tests should verify observable behavior through the public contract.

--- a/docs/prompts/unit-tests/step5-fix-broken-tests.md
+++ b/docs/prompts/unit-tests/step5-fix-broken-tests.md
@@ -1,0 +1,10 @@
+We're working on the unit tests for our `backend/app/infrastructure/security/auth.py` component as defined by the public contract at `backend/contracts/infrastructure/security/auth.pyi`. The tests are located in `backend/tests/infrastructure/security/auth/*.py`. Please investigate the skip, error, and/or failure messages below that were created during the unit test implementation. Propose test updates, fixture updates, or changes to production code to better fulfill the public contract. Do not make any file edits yet. Present your findings and recommendations for discussion.
+
+```
+SKIPPED [1] backend/tests/infrastructure/security/test_api_key_auth.py:788: Current implementation doesn't clean up metadata during reload_keys - metadata persists even after keys are removed
+SKIPPED [1] backend/tests/infrastructure/security/test_api_key_auth.py:957: Current implementation doesn't handle environment detection failures gracefully
+SKIPPED [1] backend/tests/infrastructure/security/test_api_key_auth.py:811: Current implementation doesn't maintain consistency between api_keys and metadata during reload_keys
+SKIPPED [1] backend/tests/infrastructure/security/test_api_key_auth.py:766: Current implementation doesn't clean up metadata during reload_keys - only adds new keys without removing old metadata
+``` 
+
+Are there any class or method docstring updates required after your production code changes or is the public contract unchanged?


### PR DESCRIPTION
Add a new unit-test prompt guiding senior engineers to summarize key
testing principles and anti-patterns to improve test and
consistency.

Update Makefile repomix targets:
- Exclude repomix-instructions.md from generated backend contract
  outputs to avoid duplicating instruction content in the docs.
- Add repomix-backend-environment (+ tests) targets to generate
  environment documentation (uncompressed, compressed, and contract-
  specific outputs), with appropriate include/ignore patterns.
- Add repomix-backend-security-auth (+ tests) targets to generate
  security and authentication documentation, collecting security and
  auth-related files from backend and docs while ignoring contracts
  and code_ref directories.

These changes centralize documentation generation for environment and
security concerns and prevent instruction files from polluting contract
outputs.