### PR TITLE
docker-pip-switch

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,16 +1,5 @@
-# Poetry installation stage
-FROM python:3.13-slim AS poetry-base
-
-# Install Poetry
-RUN pip install poetry==2.1.4
-
-# Configure Poetry for Docker
-ENV POETRY_NO_INTERACTION=1 \
-    POETRY_VENV_IN_PROJECT=1 \
-    POETRY_CACHE_DIR=/tmp/poetry_cache
-
 # Dependency stage
-FROM poetry-base AS dependencies
+FROM python:3.13-slim AS dependencies
 
 WORKDIR /app
 
@@ -23,16 +12,11 @@ RUN apt-get update && apt-get install -y \
 # Copy shared directory first for shared library installation
 COPY shared/ ./shared/
 
-# Choose installation method based on available files
-COPY backend/pyproject.toml* backend/poetry.lock* backend/requirements.txt* backend/requirements.docker.txt* ./
+# Copy requirements for Docker build
+COPY backend/requirements.docker.txt ./
 
-# Install dependencies with Poetry if pyproject.toml exists, otherwise use pip
-RUN if [ -f "pyproject.toml" ]; then \
-        cd ../shared && poetry install && cd /app; \
-        poetry install --only=main && rm -rf $POETRY_CACHE_DIR; \
-    else \
-        pip install --no-cache-dir -r requirements.docker.txt; \
-    fi
+# Install dependencies using pip (simpler than Poetry for Docker)
+RUN pip install --no-cache-dir -r requirements.docker.txt
 
 # Base stage
 FROM dependencies AS base
@@ -73,21 +57,6 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
 # Run the application with hot reload
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-# Production export stage (for Poetry optimization)
-FROM poetry-base AS production-export
-
-WORKDIR /app
-
-# Copy shared and backend Poetry files
-COPY shared/ ./shared/
-COPY backend/pyproject.toml* backend/poetry.lock* ./
-
-# Export requirements.txt for production build
-RUN if [ -f "pyproject.toml" ]; then \
-        cd ../shared && poetry install && cd /app; \
-        poetry export -f requirements.txt --output requirements-prod.txt --without-hashes; \
-    fi
-
 # Production stage
 FROM python:3.13-slim AS production
 
@@ -102,14 +71,9 @@ RUN apt-get update && apt-get install -y \
 COPY shared/ ./shared/
 
 # Install production dependencies
-COPY backend/requirements.lock* ./
-COPY --from=production-export /app/requirements-prod.txt* ./
+COPY backend/requirements.docker.txt ./
 
-RUN if [ -f "requirements-prod.txt" ]; then \
-        pip install --no-cache-dir -r requirements-prod.txt; \
-    else \
-        pip install --no-cache-dir -r requirements.lock; \
-    fi
+RUN pip install --no-cache-dir -r requirements.docker.txt
 
 # Copy backend application code (excluding local shared directory)
 COPY backend/app/ ./app/

--- a/docs/guides/developer/DOCKER.md
+++ b/docs/guides/developer/DOCKER.md
@@ -1,15 +1,71 @@
 # Docker Setup & Usage
 
-This project includes a comprehensive Docker setup for both development and production environments.
+This project includes a comprehensive Docker setup for both development and production environments with simplified dependency management using pip for containerized builds.
 
 ## Architecture
 
 The Docker setup includes the following services:
 
-- **Backend**: FastAPI application with AI text processing capabilities
-- **Frontend**: Streamlit web interface
-- **Redis**: Caching and session storage
+- **Backend**: FastAPI application with dual-API architecture and AI text processing capabilities
+- **Frontend**: Streamlit web interface with async API communication
+- **Redis**: AI response caching with graceful degradation and performance monitoring
 - **Nginx**: Reverse proxy and load balancer (production only)
+
+## Dependency Management Strategy
+
+**Docker builds use pip instead of Poetry for simplified dependency management:**
+
+- **Local Development**: Poetry for dependency management and virtual environments
+- **Docker Containers**: pip with `requirements.docker.txt` files for simplified builds
+- **Shared Library**: Automatically installed as editable package (`-e file:./shared`)
+
+This approach eliminates Poetry workspace dependency complexity in Docker builds while maintaining Poetry benefits for local development.
+
+## Poetry vs pip Strategy
+
+### Why pip for Docker?
+
+**Poetry Challenges in Docker**:
+- Complex workspace dependencies with shared libraries
+- Lock file synchronization issues between host and container
+- Mixed Poetry/setuptools dependency resolution conflicts
+- Increased build complexity and longer build times
+
+**pip Benefits for Docker**:
+- Simple, reliable dependency installation
+- Direct editable installs for shared libraries (`-e file:./shared`)
+- Consistent behavior across different environments
+- Faster, more predictable builds
+
+### Development Workflow
+
+```bash
+# Local development - use Poetry for dependency management
+poetry install
+poetry add new-package
+
+# Docker development - dependencies automatically handled
+make dev
+
+# Update Docker requirements when adding dependencies
+# (requirements.docker.txt files are maintained manually)
+```
+
+### File Structure
+```
+├── backend/
+│   ├── Dockerfile              # Uses pip + requirements.docker.txt
+│   ├── pyproject.toml          # Poetry for local development
+│   ├── poetry.lock            # Poetry lock file
+│   └── requirements.docker.txt # Docker-specific requirements
+├── frontend/
+│   ├── Dockerfile              # Uses pip + requirements.docker.txt
+│   ├── pyproject.toml          # Poetry for local development
+│   └── requirements.docker.txt # Docker-specific requirements
+└── shared/
+    ├── pyproject.toml          # setuptools (not Poetry)
+    └── README.md               # Required for setuptools build
+```
 
 ## Quick Start
 
@@ -35,22 +91,25 @@ docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 
 ## Environment Variables
 
-Create a `.env` file in the root directory with the following variables:
+Create a `.env` file in the root directory. For complete configuration details, see [`docs/get-started/ENVIRONMENT_VARIABLES.md`](../../get-started/ENVIRONMENT_VARIABLES.md).
+
+### Essential Docker Configuration:
 
 ```env
 # Authentication Configuration
 AUTH_MODE=simple                      # "simple" or "advanced"
 API_KEY=your-secure-api-key-here      # Primary API key
 ADDITIONAL_API_KEYS=key1,key2,key3    # Optional additional keys
-ENABLE_USER_TRACKING=false            # Enable user context tracking (advanced mode)
-ENABLE_REQUEST_LOGGING=false          # Enable security event logging (advanced mode)
 
-# Resilience Configuration
-RESILIENCE_PRESET=development         # "simple", "development", or "production"
+# Resilience Configuration (simplified preset-based)
+RESILIENCE_PRESET=development         # Choose: "simple", "development", "production"
+
+# Cache Configuration (simplified preset-based)
+CACHE_PRESET=development              # Choose: "disabled", "minimal", "simple", "development", "production", "ai-development", "ai-production"
 
 # AI Configuration
 GEMINI_API_KEY=your_gemini_api_key_here
-AI_MODEL=gemini-2.0-flash-exp
+AI_MODEL=gemini-2.5-flash-lite
 AI_TEMPERATURE=0.7
 
 # Application Configuration
@@ -59,50 +118,74 @@ LOG_LEVEL=INFO
 SHOW_DEBUG_INFO=false
 MAX_TEXT_LENGTH=10000
 
-# Infrastructure Configuration
+# Infrastructure Configuration (Docker-specific paths)
 REDIS_URL=redis://redis:6379
+CACHE_REDIS_URL=redis://redis:6379
 CORS_ORIGINS=["http://localhost:8501", "http://frontend:8501"]
 
 # Security Configuration (Production)
 DISABLE_INTERNAL_DOCS=false          # Set to true in production
 ```
 
+### Cache Preset Options:
+- **`disabled`**: No caching
+- **`minimal`**: Memory-only cache with basic settings
+- **`simple`**: Memory cache with moderate TTLs
+- **`development`**: Memory + Redis fallback, short TTLs for testing
+- **`production`**: Redis-first with memory fallback, optimized TTLs
+- **`ai-development`**: AI-optimized settings for development
+- **`ai-production`**: AI-optimized settings for production
+
 ## Available Commands
 
 Use the Makefile for easy Docker management:
 
+### Development & Production:
 ```bash
 make help              # Show all available commands
-make build             # Build all Docker images
-make up                # Start all services
-make down              # Stop all services
-make dev               # Start development environment
+make dev               # Start development environment with hot reload
 make prod              # Start production environment
-make logs              # Show logs for all services
-make status            # Show status of all services
-make health            # Check health of all services
-make clean             # Clean up Docker resources
-make test              # Run tests
-make restart           # Restart all services
+make restart           # Restart all Docker services
+make stop              # Stop all services
 ```
 
-### Service-specific commands:
+### Docker Operations:
+```bash
+make docker-build      # Build all Docker images
+make docker-up         # Start services with Docker Compose
+make docker-down       # Stop and remove Docker services
+```
 
+### Service Management:
+```bash
+make status            # Show status of all services
+make health            # Check health of all services
+make logs              # Show logs for all services
+make backend-logs      # Show backend container logs
+make frontend-logs     # Show frontend container logs
+```
+
+### Container Access:
 ```bash
 make backend-shell     # Get shell access to backend container
 make frontend-shell    # Get shell access to frontend container
-make backend-logs      # Show backend logs
-make frontend-logs     # Show frontend logs
-make redis-logs        # Show Redis logs
-make nginx-logs        # Show Nginx logs
-make redis-cli         # Open Redis CLI
+make redis-cli         # Open Redis command line interface
 ```
 
-### Backup and restore:
-
+### Data Management:
 ```bash
-make backup            # Backup Redis data
-make restore BACKUP=filename  # Restore Redis data
+make backup            # Backup Redis data with timestamp
+make restore BACKUP=filename  # Restore Redis data from backup
+```
+
+### Configuration Management:
+```bash
+make list-resil-presets        # List available resilience presets
+make show-resil-preset PRESET=simple  # Show preset details
+make validate-resil-config     # Validate current resilience configuration
+make list-cache-presets        # List available cache presets
+make show-cache-preset PRESET=development  # Show cache preset details
+make validate-cache-config     # Validate current cache configuration
 ```
 
 ## Service Details
@@ -110,42 +193,49 @@ make restore BACKUP=filename  # Restore Redis data
 ### Backend (FastAPI)
 
 - **Port**: 8000
-- **Health Check**: `http://localhost:8000/health`
+- **Health Check**: `http://localhost:8000/v1/health`
 - **API Documentation**:
-  - Public API: `http://localhost:8000/docs`
+  - Public API: `http://localhost:8000/docs` (dual-API architecture)
   - Internal API: `http://localhost:8000/internal/docs` (dev only)
-- **Features**:
+- **Key Features**:
   - **Dual-API Architecture**: Public (`/v1/`) and Internal (`/internal/`) endpoints
+  - **Preset-based Configuration**: Simplified resilience and cache management
   - **Multi-mode Authentication**: Simple and advanced modes with security features
+  - **AI Infrastructure**: PydanticAI integration with Gemini models
   - **Resilience Patterns**: Circuit breakers, retry logic, graceful degradation
-  - **Comprehensive Monitoring**: 38 resilience endpoints across 8 modules
-  - **Multi-stage Docker build** (development/production)
-  - **Hot reloading** in development
-  - **Non-root user** in production
+  - **Cache Infrastructure**: Redis with memory fallback and performance monitoring
+- **Docker Build**:
+  - **Dependency Management**: pip with `requirements.docker.txt`
+  - **Shared Library**: Automatically installed as editable package
+  - **Multi-stage Build**: Separate development/production stages
+  - **Hot Reloading**: Development mode with uvicorn auto-reload
 
 ### Frontend (Streamlit)
 
 - **Port**: 8501
 - **Health Check**: `http://localhost:8501/_stcore/health`
-- **Features**:
+- **Key Features**:
   - **Production-ready UI**: Modern interface patterns for AI applications
-  - **Authentication Integration**: Support for both simple and advanced auth modes
-  - **Real-time Monitoring**: API health checks with visual indicators
   - **Async API Communication**: Proper timeout and error handling for backend calls
-  - **Multi-stage Docker build**
-  - **Auto-reload** on file changes in development
-  - **WebSocket support** for real-time updates
+  - **Real-time Monitoring**: API health checks with visual indicators
+  - **Dynamic Configuration**: Backend-driven UI generation
+  - **Session State Management**: Stateful user interactions with persistence
+- **Docker Build**:
+  - **Dependency Management**: pip with `requirements.docker.txt`
+  - **Shared Library**: Automatically installed as editable package
+  - **Hot Reloading**: File watching for development
+  - **WebSocket Support**: Real-time updates and notifications
 
 ### Redis
 
 - **Port**: 6379
-- **Features**:
+- **Key Features**:
   - **AI Response Caching**: Optimized cache with compression and graceful degradation
-  - **Fallback Support**: System automatically falls back to in-memory cache if Redis unavailable  
+  - **Preset-based Configuration**: Simplified cache management via `CACHE_PRESET`
+  - **Fallback Support**: Automatic fallback to in-memory cache if Redis unavailable
   - **Performance Monitoring**: Built-in cache metrics and performance tracking
-  - **Persistent data storage**
-  - **Health monitoring**
-  - **Backup/restore capabilities**
+  - **Data Persistence**: Redis data survives container restarts
+  - **Backup/Restore**: Automated backup with timestamp and restore capabilities
 
 ### Nginx (Production Only)
 
@@ -159,20 +249,21 @@ make restore BACKUP=filename  # Restore Redis data
 
 ## Development vs Production
 
-### Development Features:
-- Hot reloading for both backend and frontend
-- Debug mode enabled
-- Volume mounts for live code editing
-- Development dependencies included
-- Detailed logging
+### Development Features (`make dev`):
+- **Hot Reloading**: uvicorn auto-reload for backend, Streamlit file watching for frontend
+- **Debug Mode**: Detailed logging and error messages
+- **Volume Mounts**: Live code editing with immediate reflection
+- **Full Dependencies**: All development and testing dependencies included
+- **Internal API Access**: `/internal/docs` available for debugging
+- **Configuration**: `CACHE_PRESET=development`, `RESILIENCE_PRESET=development`
 
-### Production Features:
-- Optimized builds without development dependencies
-- Non-root users for security
-- Resource limits and scaling
-- No volume mounts for security
-- Nginx reverse proxy
-- Health checks and monitoring
+### Production Features (`make prod`):
+- **Optimized Builds**: Minimal dependencies, multi-stage builds for smaller images
+- **Security Hardening**: Non-root users, no debug information exposure
+- **Performance Tuning**: Resource limits, optimized configurations
+- **Infrastructure**: Nginx reverse proxy, SSL/TLS termination ready
+- **Monitoring**: Health checks, performance metrics, structured logging
+- **Configuration**: `CACHE_PRESET=production`, `RESILIENCE_PRESET=production`
 
 ## Networking
 
@@ -206,43 +297,82 @@ The production setup supports horizontal scaling:
 
 ## Troubleshooting
 
-### Check service status:
+### Common Issues
+
+#### 1. Shared Library Dependency Issues
+**Problem**: Build fails with shared library path errors
+**Solution**: The project now uses pip instead of Poetry for Docker builds
+- Docker builds use `requirements.docker.txt` with `-e file:./shared`
+- Local development continues to use Poetry
+- This eliminates workspace dependency complexity
+
+#### 2. Port Conflicts
+**Problem**: Ports 8000, 8501, or 6379 already in use
+**Solution**:
 ```bash
-make status
-make health
+# Check what's using the ports
+lsof -i :8000 -i :8501 -i :6379
+
+# Stop conflicting services or use different ports in .env
+BACKEND_PORT=8001
+FRONTEND_PORT=8502
+REDIS_PORT=6380
 ```
 
-### View logs:
+#### 3. Cache Configuration Issues
+**Problem**: Redis connection errors or cache misses
+**Solution**:
 ```bash
-make logs                # All services
-make backend-logs        # Backend only
-make frontend-logs       # Frontend only
+# Validate cache configuration
+make validate-cache-config
+
+# Check available cache presets
+make list-cache-presets
+
+# Use development preset for local work
+CACHE_PRESET=development
 ```
 
-### Access containers:
+### Diagnostic Commands
+
+#### Check service status:
 ```bash
-make backend-shell       # Backend container
-make frontend-shell      # Frontend container
-make redis-cli          # Redis CLI
+make status             # Container status
+make health             # Health check results
+make logs               # All service logs
 ```
 
-### Test API endpoints:
+#### Access services:
+```bash
+make backend-shell      # Backend container shell
+make frontend-shell     # Frontend container shell
+make redis-cli          # Redis command line
+```
+
+#### Test endpoints:
 ```bash
 # Test health endpoints
-curl http://localhost:8000/health
-curl http://localhost:8000/internal/monitoring/overview
+curl http://localhost:8000/v1/health
+curl http://localhost:8501/_stcore/health
 
-# Test authentication (replace with your API key)
+# Test monitoring endpoints
+curl http://localhost:8000/internal/monitoring/overview
+curl http://localhost:8000/internal/cache/stats
+
+# Test API with authentication
 curl -H "Authorization: Bearer your-api-key" \
      -H "Content-Type: application/json" \
      -d '{"text":"Test","operation":"summarize"}' \
      http://localhost:8000/v1/text_processing/process
 ```
 
-### Clean up issues:
+### Clean Up Commands
+
 ```bash
-make clean              # Remove containers and volumes
-docker system prune -a  # Clean all Docker resources
+make docker-down        # Stop and remove containers
+make clean              # Clean Python cache files
+docker system prune -a  # Clean all Docker resources (use carefully)
+docker volume prune     # Remove unused volumes
 ```
 
 ## SSL/TLS Setup (Production)
@@ -256,36 +386,62 @@ To enable HTTPS in production:
 ## Monitoring and Logging
 
 ### Built-in Monitoring Endpoints
-- **System Health**: `http://localhost:8000/health`
-- **Comprehensive Monitoring**: `http://localhost:8000/internal/monitoring/overview`
+- **System Health**: `http://localhost:8000/v1/health`
+- **Internal Monitoring**: `http://localhost:8000/internal/monitoring/overview`
 - **Resilience Status**: `http://localhost:8000/internal/resilience/health`
-- **Cache Performance**: `http://localhost:8000/internal/monitoring/cache-stats`
+- **Cache Statistics**: `http://localhost:8000/internal/cache/stats`
+- **Frontend Health**: `http://localhost:8501/_stcore/health`
 
-### Features
-- **Structured logging** across all services
-- **Health checks** provide real-time service status
-- **Performance metrics** for cache and resilience patterns
-- **Redis data persistence** across container restarts
-- **Backup/restore functionality** for Redis data
-- **Circuit breaker monitoring** with automatic recovery
+### Configuration Validation
+```bash
+# Validate resilience configuration
+make validate-resil-config
+make list-resil-presets
+
+# Validate cache configuration
+make validate-cache-config
+make list-cache-presets
+```
+
+### Logging Features
+- **Structured Logging**: JSON-formatted logs across all services
+- **Service Discovery**: Automatic health check integration
+- **Performance Metrics**: Cache hit rates, response times, circuit breaker status
+- **Data Persistence**: Redis data and logs survive container restarts
+- **Real-time Monitoring**: Live health status updates
 
 ## Performance Optimization
 
-- Multi-stage builds reduce image size
-- Resource limits prevent resource exhaustion
-- Redis caching improves response times
-- Nginx load balancing distributes traffic
+### Docker Build Optimization
+- **Multi-stage Builds**: Separate development/production stages reduce image size
+- **pip vs Poetry**: Simplified dependency resolution eliminates Poetry workspace complexity
+- **Layer Caching**: Optimized Dockerfile layer ordering for faster rebuilds
+- **Shared Library**: Editable install (`-e file:./shared`) enables efficient development
+
+### Runtime Performance
+- **Preset-based Configuration**: Simplified cache and resilience management
+- **Redis Caching**: AI response caching with automatic fallback to memory
+- **Connection Pooling**: Optimized Redis and HTTP connection management
+- **Circuit Breakers**: Automatic protection against cascading failures
+- **Resource Limits**: Prevents resource exhaustion in production
 
 ## Related Documentation
 
 ### Prerequisites
 - **[Complete Setup Guide](../../get-started/SETUP_INTEGRATION.md)**: Basic understanding of the template structure and components
+- **[Environment Variables](../../get-started/ENVIRONMENT_VARIABLES.md)**: Complete configuration reference
 
-### Related Topics
-- **[Virtual Environment Guide](./VIRTUAL_ENVIRONMENT_GUIDE.md)**: Alternative local development setup without Docker
-- **[Testing Guide](../TESTING.md)**: Docker-based testing environments and strategies
+### Configuration & Infrastructure
+- **[Cache Infrastructure](../infrastructure/CACHE.md)**: Redis caching and preset configuration
+- **[Resilience Infrastructure](../infrastructure/RESILIENCE.md)**: Circuit breakers and retry patterns
+- **[Monitoring Infrastructure](../infrastructure/MONITORING.md)**: Health checks and performance metrics
 
-### Next Steps
+### Development & Testing
+- **[Virtual Environment Guide](./VIRTUAL_ENVIRONMENT_GUIDE.md)**: Alternative local development without Docker
+- **[Testing Guide](../testing/TESTING.md)**: Docker-based testing environments and strategies
+- **[Backend Guide](../BACKEND.md)**: FastAPI service architecture and implementation
+- **[Frontend Guide](../FRONTEND.md)**: Streamlit application and async patterns
+
+### Production & Deployment
 - **[Deployment Guide](../DEPLOYMENT.md)**: Production deployment using Docker and container orchestration
-- **[Backend Guide](../BACKEND.md)**: Understanding the backend services being containerized
-- **[Frontend Guide](../FRONTEND.md)**: Understanding the frontend services being containerized 
+- **[Code Standards](./CODE_STANDARDS.md)**: Development standards and architectural guidelines 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,40 +10,20 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Poetry
-RUN pip install poetry==2.1.4
-
-# Configure Poetry
-ENV POETRY_NO_INTERACTION=1 \
-    POETRY_VENV_IN_PROJECT=1 \
-    POETRY_CACHE_DIR=/tmp/poetry_cache
-
 # Copy shared directory first for shared library installation
 COPY shared/ ./shared/
 
-# Choose installation method based on available files
-COPY frontend/pyproject.toml* frontend/poetry.lock* frontend/requirements.txt* frontend/requirements.docker.txt* ./
+# Copy requirements for Docker build
+COPY frontend/requirements.docker.txt ./
 
-# Install dependencies with Poetry if pyproject.toml exists, otherwise use pip
-RUN if [ -f "pyproject.toml" ]; then \
-        cd ../shared && poetry install && cd /app; \
-        poetry install --only=main && rm -rf $POETRY_CACHE_DIR; \
-    else \
-        pip install --no-cache-dir -r requirements.docker.txt; \
-    fi
+# Install dependencies using pip (simpler than Poetry for Docker)
+RUN pip install --no-cache-dir -r requirements.docker.txt
 
 # Add shared models to Python path - app package is already available from /app
 ENV PYTHONPATH="${PYTHONPATH}:/app"
 
 # Development stage
 FROM base AS development
-
-# Install development dependencies
-RUN if [ -f "pyproject.toml" ]; then \
-        poetry install --with dev && rm -rf $POETRY_CACHE_DIR; \
-    else \
-        pip install --no-cache-dir -r requirements-dev.txt; \
-    fi
 
 # Copy frontend application code (excluding local shared directory)
 COPY frontend/app/ ./app/
@@ -67,13 +47,6 @@ CMD ["python", "run_app.py"]
 
 # Production stage
 FROM base AS production
-
-# Install production dependencies
-RUN if [ -f "pyproject.toml" ]; then \
-        poetry install --only=main && rm -rf $POETRY_CACHE_DIR; \
-    else \
-        pip install --no-cache-dir -r requirements.lock; \
-    fi
 
 # Copy frontend application code (excluding local shared directory)
 COPY frontend/app/ ./app/

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,1 @@
+shared/README.md


### PR DESCRIPTION
- Switched Dockerfile to use pip instead of Poetry for installing dependencies.
- Added README link in a subfolder.
- Documented a hybrid approach supporting both Poetry and pip with Docker.