### PR TITLE
docs: add preferred cache factory instantiation throughout cache documentation

### DIFF
--- a/backend/app/infrastructure/cache/README.md
+++ b/backend/app/infrastructure/cache/README.md
@@ -30,6 +30,100 @@ async def process_data(
     return result
 ```
 
+## Factory vs Direct Instantiation
+
+### Recommended Approach: Factory Methods
+
+**For 90% of use cases, use factory methods instead of direct instantiation** for optimized defaults, comprehensive validation, and built-in error handling.
+
+```python
+# ✅ RECOMMENDED: Factory method approach
+from app.infrastructure.cache import CacheFactory
+
+factory = CacheFactory()
+
+# Web applications
+cache = await factory.for_web_app(
+    redis_url="redis://localhost:6379",
+    default_ttl=1800  # 30 minutes
+)
+
+# AI applications
+ai_cache = await factory.for_ai_app(
+    redis_url="redis://localhost:6379",
+    default_ttl=3600,  # 1 hour
+    operation_ttls={
+        "summarize": 7200,  # 2 hours
+        "sentiment": 86400  # 24 hours
+    }
+)
+
+# Testing
+test_cache = await factory.for_testing(use_memory_cache=True)
+```
+
+### Factory Method Benefits
+
+- **Environment-Optimized Defaults**: Presets for web, AI, and testing scenarios
+- **Comprehensive Validation**: Parameter validation with detailed error messages
+- **Graceful Fallback**: Automatic fallback to InMemoryCache when Redis unavailable
+- **Security Integration**: Built-in security configuration and TLS support
+- **Error Handling**: Structured error handling with proper context
+
+### When to Use Direct Instantiation
+
+**Reserve direct instantiation for specialized requirements:**
+
+```python
+# ⚠️ ADVANCED: Direct instantiation for fine-grained control
+from app.infrastructure.cache import AIResponseCache
+
+cache = AIResponseCache(
+    redis_url="redis://custom-host:6380/5",
+    default_ttl=7200,
+    text_hash_threshold=2000,
+    compression_threshold=500,
+    compression_level=9,
+    l1_cache_size=300,
+    operation_ttls={"custom_op": 1800},
+    fail_on_connection_error=True
+)
+
+# Manual connection handling required
+connected = await cache.connect()
+if not connected:
+    raise InfrastructureError("Cache connection required")
+```
+
+**Use direct instantiation when:**
+- Building custom cache implementations
+- Requiring exact parameter combinations not supported by factory methods
+- Developing reusable cache components
+- Migrating legacy code with specific configurations
+
+### Migration from Direct to Factory
+
+```python
+# Before: Direct instantiation
+cache = AIResponseCache(
+    redis_url="redis://localhost:6379",
+    default_ttl=3600,
+    text_hash_threshold=1000,
+    compression_threshold=1000
+)
+
+# After: Factory method (recommended)
+factory = CacheFactory()
+cache = await factory.for_ai_app(
+    redis_url="redis://localhost:6379",
+    default_ttl=3600,
+    text_hash_threshold=1000,
+    compression_threshold=1000
+)
+```
+
+**📖 For comprehensive factory usage patterns and examples, see [Cache Usage Guide](../../../docs/guides/infrastructure/cache/usage-guide.md).**
+
 ## Architecture Overview
 
 ### Cache Interface

--- a/backend/app/infrastructure/cache/memory.py
+++ b/backend/app/infrastructure/cache/memory.py
@@ -71,6 +71,60 @@ active_keys = [k for k in keys_to_check if await cache.exists(k)]
 cache.clear()  # Clear all entries
 ```
 
+## Usage Patterns
+
+### Factory Method (Recommended for Most Cases)
+
+**Use factory methods for consistent configuration and testing patterns:**
+
+```python
+from app.infrastructure.cache import CacheFactory
+
+factory = CacheFactory()
+
+# Testing scenarios - recommended approach
+test_cache = await factory.for_testing(
+    use_memory_cache=True,
+    default_ttl=60,  # 1 minute for tests
+    l1_cache_size=50
+)
+
+# Development environments
+dev_cache = await factory.for_web_app(
+    redis_url="redis://localhost:6379",
+    fail_on_connection_error=False  # Falls back to InMemoryCache
+)
+```
+
+**Factory Method Benefits:**
+- Consistent test environment configurations
+- Automatic fallback behavior when Redis unavailable
+- Environment-optimized defaults
+- Built-in parameter validation
+
+### Direct Instantiation (Appropriate for)
+
+**Use direct instantiation for simple applications and exact control scenarios:**
+
+```python
+# Testing scenarios requiring exact control
+cache = InMemoryCache(default_ttl=1800, max_size=500)
+
+# Simple applications with basic cache needs
+cache = InMemoryCache(default_ttl=7200, max_size=2000)
+
+# Fallback cache implementations
+cache = InMemoryCache(default_ttl=3600, max_size=1000)
+```
+
+**Use direct instantiation when:**
+- Building simple applications with basic caching needs
+- Testing scenarios requiring exact behavioral control
+- Implementing fallback cache strategies
+- Developing specialized cache components
+
+**📖 For comprehensive factory usage patterns and configuration examples, see [Cache Usage Guide](../../../docs/guides/infrastructure/cache/usage-guide.md).**
+
 Performance Characteristics:
 ----------------------------
 - **Get Operations**: O(1) average case, O(n) worst case during cleanup

--- a/backend/app/infrastructure/cache/redis_ai.py
+++ b/backend/app/infrastructure/cache/redis_ai.py
@@ -26,11 +26,71 @@ Inheritance pattern:
 - **AIResponseCache**: Adds AI-specific optimizations and intelligent features
 - **CacheParameterMapper**: Handles parameter validation and mapping
 
-## Usage
+## Usage Patterns
+
+### Factory Method (Recommended)
+
+**Most AI applications should use factory methods for AI-optimized defaults and intelligent features:**
 
 ```python
-cache = AIResponseCache(redis_url="redis://localhost:6379")
-await cache.connect()
+from app.infrastructure.cache import CacheFactory
+
+factory = CacheFactory()
+
+# AI applications - recommended approach
+cache = await factory.for_ai_app(
+    redis_url="redis://localhost:6379",
+    default_ttl=3600,  # 1 hour
+    operation_ttls={
+        "summarize": 7200,  # 2 hours - summaries are stable
+        "sentiment": 86400,  # 24 hours - sentiment rarely changes
+        "translate": 14400   # 4 hours - translations moderately stable
+    }
+)
+
+# Production AI cache with security
+from app.infrastructure.security import SecurityConfig
+security_config = SecurityConfig(
+    redis_auth="ai-cache-password",
+    use_tls=True,
+    verify_certificates=True
+)
+cache = await factory.for_ai_app(
+    redis_url="rediss://ai-production:6380",
+    security_config=security_config,
+    text_hash_threshold=1000,
+    fail_on_connection_error=True
+)
+```
+
+**Factory Method Benefits for AI Applications:**
+- AI-optimized defaults with operation-specific TTLs
+- Intelligent text hashing for large inputs
+- Enhanced compression for AI response storage
+- AI-specific monitoring and performance analytics
+- Automatic fallback with graceful degradation
+
+### Direct Instantiation (Advanced AI Use Cases)
+
+**Use direct instantiation for specialized AI cache configurations:**
+
+```python
+cache = AIResponseCache(
+    redis_url="redis://localhost:6379",
+    default_ttl=3600,
+    text_hash_threshold=500,
+    operation_ttls={
+        "custom_ai_operation": 1800,
+        "specialized_nlp": 7200
+    },
+    compression_threshold=1000,
+    compression_level=8
+)
+
+# Manual connection handling required
+connected = await cache.connect()
+if not connected:
+    raise InfrastructureError("AI cache connection required")
 
 # AI response caching with intelligent key generation
 key = cache.build_key(
@@ -39,9 +99,15 @@ key = cache.build_key(
     options={"max_length": 100}
 )
 await cache.set(key, {"summary": "Brief summary"}, ttl=3600)
-        ...         'large': 30000
-        ...     }
-        ... )
+```
+
+**Use direct instantiation when:**
+- Building custom AI cache implementations with specialized features
+- Requiring exact AI parameter combinations not supported by factory methods
+- Developing AI-specific frameworks or libraries
+- Migrating legacy AI systems with custom configurations
+
+**📖 For comprehensive factory usage patterns and AI-specific configuration examples, see [Cache Usage Guide](../../../docs/guides/infrastructure/cache/usage-guide.md).**
 
 Dependencies:
     Required:

--- a/backend/contracts/infrastructure/cache/memory.pyi
+++ b/backend/contracts/infrastructure/cache/memory.pyi
@@ -71,6 +71,60 @@ active_keys = [k for k in keys_to_check if await cache.exists(k)]
 cache.clear()  # Clear all entries
 ```
 
+## Usage Patterns
+
+### Factory Method (Recommended for Most Cases)
+
+**Use factory methods for consistent configuration and testing patterns:**
+
+```python
+from app.infrastructure.cache import CacheFactory
+
+factory = CacheFactory()
+
+# Testing scenarios - recommended approach
+test_cache = await factory.for_testing(
+    use_memory_cache=True,
+    default_ttl=60,  # 1 minute for tests
+    l1_cache_size=50
+)
+
+# Development environments
+dev_cache = await factory.for_web_app(
+    redis_url="redis://localhost:6379",
+    fail_on_connection_error=False  # Falls back to InMemoryCache
+)
+```
+
+**Factory Method Benefits:**
+- Consistent test environment configurations
+- Automatic fallback behavior when Redis unavailable
+- Environment-optimized defaults
+- Built-in parameter validation
+
+### Direct Instantiation (Appropriate for)
+
+**Use direct instantiation for simple applications and exact control scenarios:**
+
+```python
+# Testing scenarios requiring exact control
+cache = InMemoryCache(default_ttl=1800, max_size=500)
+
+# Simple applications with basic cache needs
+cache = InMemoryCache(default_ttl=7200, max_size=2000)
+
+# Fallback cache implementations
+cache = InMemoryCache(default_ttl=3600, max_size=1000)
+```
+
+**Use direct instantiation when:**
+- Building simple applications with basic caching needs
+- Testing scenarios requiring exact behavioral control
+- Implementing fallback cache strategies
+- Developing specialized cache components
+
+**📖 For comprehensive factory usage patterns and configuration examples, see [Cache Usage Guide](../../../docs/guides/infrastructure/cache/usage-guide.md).**
+
 Performance Characteristics:
 ----------------------------
 - **Get Operations**: O(1) average case, O(n) worst case during cleanup

--- a/backend/contracts/infrastructure/cache/redis_ai.pyi
+++ b/backend/contracts/infrastructure/cache/redis_ai.pyi
@@ -26,11 +26,71 @@ Inheritance pattern:
 - **AIResponseCache**: Adds AI-specific optimizations and intelligent features
 - **CacheParameterMapper**: Handles parameter validation and mapping
 
-## Usage
+## Usage Patterns
+
+### Factory Method (Recommended)
+
+**Most AI applications should use factory methods for AI-optimized defaults and intelligent features:**
 
 ```python
-cache = AIResponseCache(redis_url="redis://localhost:6379")
-await cache.connect()
+from app.infrastructure.cache import CacheFactory
+
+factory = CacheFactory()
+
+# AI applications - recommended approach
+cache = await factory.for_ai_app(
+    redis_url="redis://localhost:6379",
+    default_ttl=3600,  # 1 hour
+    operation_ttls={
+        "summarize": 7200,  # 2 hours - summaries are stable
+        "sentiment": 86400,  # 24 hours - sentiment rarely changes
+        "translate": 14400   # 4 hours - translations moderately stable
+    }
+)
+
+# Production AI cache with security
+from app.infrastructure.security import SecurityConfig
+security_config = SecurityConfig(
+    redis_auth="ai-cache-password",
+    use_tls=True,
+    verify_certificates=True
+)
+cache = await factory.for_ai_app(
+    redis_url="rediss://ai-production:6380",
+    security_config=security_config,
+    text_hash_threshold=1000,
+    fail_on_connection_error=True
+)
+```
+
+**Factory Method Benefits for AI Applications:**
+- AI-optimized defaults with operation-specific TTLs
+- Intelligent text hashing for large inputs
+- Enhanced compression for AI response storage
+- AI-specific monitoring and performance analytics
+- Automatic fallback with graceful degradation
+
+### Direct Instantiation (Advanced AI Use Cases)
+
+**Use direct instantiation for specialized AI cache configurations:**
+
+```python
+cache = AIResponseCache(
+    redis_url="redis://localhost:6379",
+    default_ttl=3600,
+    text_hash_threshold=500,
+    operation_ttls={
+        "custom_ai_operation": 1800,
+        "specialized_nlp": 7200
+    },
+    compression_threshold=1000,
+    compression_level=8
+)
+
+# Manual connection handling required
+connected = await cache.connect()
+if not connected:
+    raise InfrastructureError("AI cache connection required")
 
 # AI response caching with intelligent key generation
 key = cache.build_key(
@@ -39,9 +99,15 @@ key = cache.build_key(
     options={"max_length": 100}
 )
 await cache.set(key, {"summary": "Brief summary"}, ttl=3600)
-        ...         'large': 30000
-        ...     }
-        ... )
+```
+
+**Use direct instantiation when:**
+- Building custom AI cache implementations with specialized features
+- Requiring exact AI parameter combinations not supported by factory methods
+- Developing AI-specific frameworks or libraries
+- Migrating legacy AI systems with custom configurations
+
+**📖 For comprehensive factory usage patterns and AI-specific configuration examples, see [Cache Usage Guide](../../../docs/guides/infrastructure/cache/usage-guide.md).**
 
 Dependencies:
     Required:

--- a/backend/contracts/infrastructure/cache/redis_generic.pyi
+++ b/backend/contracts/infrastructure/cache/redis_generic.pyi
@@ -20,17 +20,73 @@ like AIResponseCache.
 - **Flexible Serialization**: Support for JSON and pickle serialization
 - **Connection Management**: Robust Redis connection handling with retry logic
 
-## Usage
+## Usage Patterns
+
+### Factory Method (Recommended)
+
+**Most applications should use factory methods for optimized defaults and built-in validation:**
 
 ```python
-cache = GenericRedisCache(redis_url="redis://localhost:6379")
-await cache.connect()
+from app.infrastructure.cache import CacheFactory
+
+factory = CacheFactory()
+
+# Web applications - recommended approach
+cache = await factory.for_web_app(
+    redis_url="redis://localhost:6379",
+    default_ttl=1800,  # 30 minutes
+    compression_threshold=2000
+)
+
+# Production with security
+from app.infrastructure.security import SecurityConfig
+security_config = SecurityConfig(redis_auth="secure-password", use_tls=True)
+cache = await factory.for_web_app(
+    redis_url="rediss://production:6380",
+    security_config=security_config,
+    fail_on_connection_error=True
+)
+```
+
+**Factory Method Benefits:**
+- Environment-optimized defaults for web applications
+- Comprehensive parameter validation with detailed error messages
+- Automatic fallback to InMemoryCache when Redis unavailable
+- Built-in security configuration and TLS support
+- Structured error handling with proper context
+
+### Direct Instantiation (Advanced Use Cases)
+
+**Use direct instantiation for fine-grained control or custom implementations:**
+
+```python
+cache = GenericRedisCache(
+    redis_url="redis://localhost:6379",
+    default_ttl=3600,
+    enable_l1_cache=True,
+    l1_cache_size=200,
+    compression_threshold=2000,
+    compression_level=6
+)
+
+# Manual connection handling required
+connected = await cache.connect()
+if not connected:
+    raise InfrastructureError("Redis connection required for this service")
 
 # Standard cache operations
 await cache.set("user:123", {"name": "John", "age": 30}, ttl=3600)
 user_data = await cache.get("user:123")
 await cache.delete("user:123")
 ```
+
+**Use direct instantiation when:**
+- Building custom cache implementations with specialized requirements
+- Requiring exact parameter combinations not supported by factory methods
+- Developing reusable cache components or frameworks
+- Migrating legacy code with specific configuration needs
+
+**📖 For comprehensive factory usage patterns and configuration examples, see [Cache Usage Guide](../../../docs/guides/infrastructure/cache/usage-guide.md).**
 """
 
 import json

--- a/docs/guides/infrastructure/cache/CACHE.md
+++ b/docs/guides/infrastructure/cache/CACHE.md
@@ -356,6 +356,80 @@ CACHE_CUSTOM_CONFIG='{"compression_threshold": 500, "memory_cache_size": 200}'
 
 **Next Steps**: See [Cache Configuration Guide](./configuration.md) for detailed configuration examples and preset-specific guidance.
 
+## Cache Instantiation Patterns
+
+### Architectural Decision: Factory vs Direct Instantiation
+
+The cache infrastructure supports two instantiation approaches, each serving different architectural needs:
+
+#### Factory Methods (Recommended Architecture)
+
+**Factory methods provide production-ready defaults and comprehensive validation** for most application scenarios:
+
+```python
+from app.infrastructure.cache import CacheFactory
+
+factory = CacheFactory()
+
+# Environment-optimized cache creation
+web_cache = await factory.for_web_app()      # Web applications
+ai_cache = await factory.for_ai_app()        # AI/ML workloads
+test_cache = await factory.for_testing()     # Testing scenarios
+```
+
+**Architectural Benefits:**
+- **Separation of Concerns**: Configuration logic separated from application logic
+- **Environment Consistency**: Standardized configurations across deployment environments
+- **Security by Default**: Built-in security configuration and validation
+- **Error Resilience**: Automatic fallback strategies and graceful degradation
+- **Operational Excellence**: Comprehensive monitoring and performance analytics
+
+#### Direct Instantiation (Specialized Architecture)
+
+**Direct instantiation provides fine-grained control** for specialized architectural requirements:
+
+```python
+from app.infrastructure.cache import AIResponseCache, GenericRedisCache
+
+# Custom cache implementation with specific architectural needs
+cache = AIResponseCache(
+    redis_url="redis://specialized-cluster:6380",
+    custom_serialization_strategy=specialized_serializer,
+    advanced_monitoring=custom_monitor,
+    specialized_compression_algorithms=custom_compressor
+)
+```
+
+**Architectural Use Cases:**
+- **Custom Infrastructure Integration**: Specialized monitoring, security, or networking requirements
+- **Performance-Critical Paths**: Optimized configurations for specific performance profiles
+- **Framework Development**: Building reusable cache components or abstractions
+- **Legacy System Integration**: Maintaining compatibility with existing infrastructure patterns
+
+### Production Architecture Recommendations
+
+**For Production Systems:**
+1. **Use factory methods** for 90% of cache implementations
+2. **Implement infrastructure-level configuration** through preset systems
+3. **Reserve direct instantiation** for specialized architectural requirements
+4. **Follow security-first principles** with built-in security configuration validation
+5. **Design for observability** with comprehensive monitoring and metrics collection
+
+**For Development and Testing:**
+1. **Use factory testing methods** for consistent test environments
+2. **Leverage preset configurations** for rapid development iteration
+3. **Implement cache-aware testing patterns** for reliable test isolation
+
+### Migration and Evolution Strategies
+
+**Migrating to Factory Patterns:**
+- **Phase 1**: Identify existing direct instantiation usage patterns
+- **Phase 2**: Map current configurations to appropriate factory methods
+- **Phase 3**: Implement factory-based instantiation with configuration validation
+- **Phase 4**: Retire direct instantiation for standard use cases
+
+**📖 For detailed implementation patterns and comprehensive examples, see [Cache Usage Guide](./usage-guide.md).**
+
 ## Integration with Infrastructure Services
 
 The Cache Infrastructure Service integrates seamlessly with other infrastructure components to provide comprehensive application support:


### PR DESCRIPTION
Provides a cohesive experience where developers encounter consistent 
factory method guidance and are directed to the comprehensive usage 
guide for detailed implementation patterns and examples